### PR TITLE
guide to deploying using github actions

### DIFF
--- a/docs/run_publish/publish.md
+++ b/docs/run_publish/publish.md
@@ -81,7 +81,7 @@ $ subql project:create-project
 
 ### Deploy your First Version
 
-There are two methods to deploy a new version of your project to the SubQuery Managed Service, you can use the UI or directly via the `subql` cli tool.
+There are three methods to deploy a new version of your project to the SubQuery Managed Service, you can use the UI or directly, via the `subql` cli tool, or using an automated GitHub Action.
 
 #### Using the UI
 
@@ -127,14 +127,26 @@ $ subql deployment:deploy
 
 #### Using Github actions
 
-With the introduction of the deployment feature for the CLI, we've added a worflow to Github that will allow you to publish and deploy with ease
+With the introduction of the deployment feature for the CLI, we've added a default Action workflow to GitHub that will allow you to publish and deploy your changes automatically:
 
-- Step 1: After pushing your project to Github, create `DEPLOYMENT` environment on Github, and add the secret [SUBQL_ACCESS_TOKEN](../run_publish/ipfs.md#prepare-your-subql-access-token) to it.
-- Step 2: Create a project on HostedServices, this can be done using the [CLI](#using-the-cli) or the [UI](#using-the-ui). 
-- Step 3: Once the project is created, navigate to the Github Actions page for your project, and select the workflow `CLI deploy`
-- Step 4: You'll see an input field where you can enter the name of your project created on HostedServices. If the name of your project contains spaces, please replace them with `-`. e.g. `my project name` becomes `my-project-name`
-- Once the workflow is complete, you should be able to your project deployed on the HostedServices.
+- Step 1: After pushing your project to GitHub, create `DEPLOYMENT` environment on GitHub, and add the secret [SUBQL_ACCESS_TOKEN](../run_publish/ipfs.md#prepare-your-subql-access-token) to it.
+- Step 2: Create a project on [SubQuery Projects](https://project.subquery.network), this can be done using the the [UI](#using-the-ui) or [CLI](#using-the-cli). 
+- Step 3: Once your project is created, navigate to the GitHub Actions page for your project, and select the workflow `CLI deploy`
+- Step 4: You'll see an input field where you can enter the unique code of your project created on SubQuery Projects, you can get the code from the URL in SubQuery Projects [SubQuery Projects](https://project.subquery.network). The code is based on the name of your project, where spaces are replaced with hyphens `-`. e.g. `my project name` becomes `my-project-name`
+- Once the workflow is complete, you should be see your project deployed to our Managed Service
 
+A common approach is to extend the default GitHub Action to automatically deploy changes to our Managed Service when code is merged into main. The following change to the GitHub Action workflow do this:
+
+```yml
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: CLI Deploy
+    ...
+```
 
 ## Next Steps - Connect to your Project
 

--- a/docs/run_publish/publish.md
+++ b/docs/run_publish/publish.md
@@ -125,6 +125,17 @@ $ subql deployment:deploy
   --type=(stage|primary)           [default: primary]
 ```
 
+#### Using Github actions
+
+With the introduction of the deployment feature for the CLI, we've added a worflow to Github that will allow you to publish and deploy with ease
+
+- Step 1: After pushing your project to Github, create `DEPLOYMENT` environment on Github, and add the secret [SUBQL_ACCESS_TOKEN](../run_publish/ipfs.md#prepare-your-subql-access-token) to it.
+- Step 2: Create a project on HostedServices, this can be done using the [CLI](#using-the-cli) or the [UI](#using-the-ui). 
+- Step 3: Once the project is created, navigate to the Github Actions page for your project, and select the workflow `CLI deploy`
+- Step 4: You'll see an input field where you can enter the name of your project created on HostedServices. If the name of your project contains spaces, please replace them with `-`. e.g. `my project name` becomes `my-project-name`
+- Once the workflow is complete, you should be able to your project deployed on the HostedServices.
+
+
 ## Next Steps - Connect to your Project
 
 Once your deployment has succesfully completed and our nodes have indexed your data from the chain, you'll be able to connect to your project via the displayed GraphQL Query endpoint.


### PR DESCRIPTION
Currently, projects created using `subql init` does not include the workflow files, but with the next release that should be resolved
