### PR TITLE
Doc GraphQL entity naming constraints

### DIFF
--- a/docs/build/graphql.md
+++ b/docs/build/graphql.md
@@ -40,6 +40,17 @@ type Example @entity {
 }
 ```
 
+### Naming Constraints
+
+You'll need to shorten the entity's name if you get an error such as the following when running the app:
+
+```shell
+subquery-notifications-postgres-1        | 2022-08-26 14:18:12.355 UTC [1922] ERROR:  constraint "bank_msg_multi_send_input_coins_bank_msg_multi_send_input_id_fk" for table "bank_msg_multi_send_input_coins" does not exist
+subquery-notifications-postgres-1        | 2022-08-26 14:18:12.355 UTC [1922] STATEMENT:  COMMENT ON CONSTRAINT bank_msg_multi_send_input_coins_bank_msg_multi_send_input_id_fkey ON "app"."bank_msg_multi_send_input_coins" IS E'@foreignFieldName coins'
+```
+
+Subquery automatically generates Postgres identifiers for your entities. For example, if you have an entity named `BankMsgMultiSendInputCoins`, then an identifier `bank_msg_multi_send_input_coins_bank_msg_multi_send_input_id_fkey` will be automatically generated in Postgres. However, this identifier is 65 bytes, and Postgres doesn't support identifiers larger than 63 bytes. In this example, shortening the entity's name to `BankMultiSendInputCoins` will resolve the issue.
+
 ### Supported scalars and types
 
 We currently support the following scalar types:


### PR DESCRIPTION
I and the Subquery team spent several hours figuring out why the database wouldn't generate a Postgres identifier for what was otherwise a perfectly written Subquery project.

Please feel free to close this PR If you deem it out of scope, or you'd rather write it yourself in a different way.