### PR TITLE
docs: fix incorrect phrasing in transaction data label

### DIFF
--- a/docs/subquery_network/data_node/introduction.md
+++ b/docs/subquery_network/data_node/introduction.md
@@ -34,7 +34,7 @@ We aim to make releases in line with the official releases. These releases inclu
 
 ### Additional Data
 
-In order to efficiently query transactions data, the nodes will now build bloom filters for each block. This bloom data is based on transaction `to`, `from` and the first 4 bytes of `input`. On top of this, there is also a bloombits indexer to increase the lookup performance of the bloom filters. This is effectively the same approach as what is used to filter logs, but applied to transactions.
+In order to efficiently query transaction data, the nodes will now build bloom filters for each block. This bloom data is based on transaction `to`, `from` and the first 4 bytes of `input`. On top of this, there is also a bloombits indexer to increase the lookup performance of the bloom filters. This is effectively the same approach as what is used to filter logs, but applied to transactions.
 
 ::: note
 


### PR DESCRIPTION
I’ve updated the phrasing from "transactions data" to the correct "transaction data" to ensure consistency and clarity in the code. This is the more commonly used term and aligns with standard conventions.