### PR TITLE
Update docs relating to ABI imports

### DIFF
--- a/docs/indexer/build/cosmos-evm.md
+++ b/docs/indexer/build/cosmos-evm.md
@@ -14,7 +14,7 @@ This document goes into detail about how to use the Ethermint Cosmos RPCs (rathe
 
 1. Add the custom datasource as a dependency:
 
-- Create a new project from an EVM template through `subql init` OR
+- Create a new project from an EVM template through `npx @subql/cli init` OR
 - For existing projects, `yarn add @subql/ethermint-evm-processor` or `npm i @subql/ethermint-evm-processor`.
 
 2. Add a custom data source as described below.

--- a/docs/indexer/build/install.md
+++ b/docs/indexer/build/install.md
@@ -1,26 +1,26 @@
 # Installation
 
-There are various components required when creating a SubQuery project. The [@subql/cli](https://github.com/subquery/subql/tree/docs-new-section/packages/cli) tool is used to create SubQuery projects. The [@subql/node](https://github.com/subquery/subql/tree/docs-new-section/packages/node) component is required to run an indexer. The [@subql/query](https://github.com/subquery/subql/tree/docs-new-section/packages/query) library is required to generate queries.
+When working with SubQuery, we recommend doing everything in a dedicated directory for your project and using Docker to run projects. Please follow the [quickstart](../quickstart/quickstart.md) for more details on how to create a SubQuery project.
 
+But if you wish to install the SubQuery components manually, you can follow the instructions below.
 ## Install @subql/cli
 
-The [@subql/cli](https://github.com/subquery/subql/tree/main/packages/cli) tool helps to create a project framework or scaffold, meaning you don't have to start from scratch.
+The [@subql/cli](https://github.com/subquery/subql/tree/main/packages/cli) tool helps to create and manage a project, meaning you don't have to start from scratch.
 
 Install SubQuery CLI globally on your terminal by using Yarn or NPM:
 
-::: code-tabs
+::: code-tabs#shell
 @tab npm
 
 ```bash
 npm install -g @subql/cli
 ```
 
-@tab:active yarn
+@tab:active yarn (not recommended)
 
 ```shell
 yarn global add @subql/cli
 ```
-
 :::
 
 You can then run help to see available commands and usage provided by CLI:
@@ -29,23 +29,27 @@ You can then run help to see available commands and usage provided by CLI:
 subql --help
 ```
 
-## Install @subql/node
+::: tip Note
+SubQuery projects will have this as a dependency in their `package.json` file, so you can also run the CLI commands using `npx` without installing it globally. For example, you can run `npx subql publish` to publish the project to IPFS.
+:::
 
-A SubQuery node is an implementation that extracts substrate-based blockchain data per the SubQuery project and saves it into a Postgres database.
+## Install @subql/node-*
+
+A SubQuery node is an implementation that runs a project to extract data from a blockchain and stores it in a database. We have multiple implementations of the SubQuery node, such as `@subql/node` (for Substrate/Polkadot), `@subql/node-evm`, and `@subql/node-cosmos`. You can choose the one that matches your project.
 
 Install SubQuery node globally on your terminal by using Yarn or NPM:
 
-::: code-tabs
+::: code-tabs#shell
 @tab npm
 
 ```bash
-npm install -g @subql/node
+npm install -g @subql/node-ethereum
 ```
 
-@tab:active yarn
+@tab:active yarn (not recommended)
 
 ```shell
-yarn global add @subql/node
+yarn global add @subql/node-ethereum
 ```
 
 :::
@@ -53,7 +57,7 @@ yarn global add @subql/node
 Once installed, you can start a node with:
 
 ```shell
-subql-node <command>
+subql-node-ethereum <command>
 ```
 
 ::: tip Note
@@ -66,14 +70,14 @@ The SubQuery query library provides a service that allows you to query your proj
 
 Install SubQuery query globally on your terminal by using Yarn or NPM:
 
-::: code-tabs
+::: code-tabs#shell
 @tab npm
 
 ```bash
 npm install -g @subql/query
 ```
 
-@tab:active yarn
+@tab:active yarn (not recommended)
 
 ```shell
 yarn global add @subql/query

--- a/docs/indexer/build/introduction.md
+++ b/docs/indexer/build/introduction.md
@@ -4,7 +4,7 @@ In the [quick start](../quickstart/quickstart.md) guide, we very quickly ran thr
 
 Some of the following examples will assume you have successfully initialized the starter package in the [Quick start](../quickstart/quickstart.md) section. From that starter package, we'll walk through the standard process to customise and implement your SubQuery project.
 
-1. Initialise your project using `subql init PROJECT_NAME`.
+1. Initialise your project using `npx @subql/cli init PROJECT_NAME`.
 2. Update the Manifest file (`project.ts`) to include information about your blockchain, and the entities that you will map - see [Manifest File](./manifest/ethereum.md).
 3. Create GraphQL entities in your schema (`schema.graphql`) that defines the shape of the data that you will extract and persist for querying - see [GraphQL Schema](./graphql.md).
 4. Add all the mapping functions (eg `mappingHandlers.ts`) you wish to invoke to transform chain data to the GraphQL entities that you have defined - see [Mapping](./mapping/ethereum.md).
@@ -38,18 +38,18 @@ For example:
 
 ![SubQuery directory structure](/assets/img/build/directory_stucture.png)
 
-## EVM and Cosmos Project Scaffolding
+## EVM ABI Importing
 
-Scaffolding saves time during SubQuery project creation by automatically generating typescript facades for EVM transactions, logs, and types.
+Importing ABIs saves time during SubQuery project creation by automatically generating typescript facades for EVM transactions, logs, and types.
 
 ### When Initialising New SubQuery Projects
 
-When you are initialising a new project using the `subql init` command, SubQuery will give you the option to set up a scaffolded SubQuery project based on your JSON ABI.
+When you are initialising a new project using the `npx @subql/cli init` command, SubQuery will give you the option to import an ABI to give you a head start by automatically generating some data sources and empty handler functions fro you.
 
 If you have select a compatible network type (EVM), it will prompt
 
 ```shell
-? Do you want to generate scaffolding with an existing abi contract?
+? Do you want to generate datasources and handlers from an existing contract ABI?
 ```
 
 Followed by prompt on the path to your ABI file (absolute or relative to your current working directory). This must be in a JSON format.
@@ -60,42 +60,49 @@ Followed by prompt on the path to your ABI file (absolute or relative to your cu
 
 So for example, If I wanted to create the [Ethereum Gravatar indexer](../quickstart/quickstart_chains/ethereum-gravatar.md), I would download the Gravity ABI contract JSON from [Etherscan](https://etherscan.io/address/0x2e645469f354bb4f5c8a05b3b30a929361cf77ec#code), save it as `Gravity.json`, and then run the following.
 
-![Project Scaffolding EVM](/assets/img/build/project-scaffold-evm.png)
+![Project ABI Import EVM](/assets/img/build/project-scaffold-evm.png)
 
 You will then be prompted to select what `events` and/or `functions` that you want to index from the provided ABI.
 
 ### For an Existing SubQuery Project
 
-You can also generate additional scaffolded code new contracts and append this code to your existing `project.ts`. This is done using the `subql codegen:generate` command from within your project workspace.
-If you have `@subql/cli` version `5.0.0` or above, you will need to install `@subql/common-ethereum` package in the dependencies before execute this command.
+You can also import ABIs into an existing SubQuery project. This is useful if you have a new contract that you want to index, or if you want to add more events or functions to your existing project. This is done using the `subql import-abi` command from within your project workspace.
+
+#### From Etherscan
+
+If the contract you wish to import is verified on Etherscan (or any other Etherscan related explorer), you can import the ABI using just the contract address. This will automatically fetch the ABI from Etherscan and generate the necessary data sources and handler functions.
+
+::: note
+You will need an Etherscan API key to use this feature. You can get one for free from [Etherscan](https://etherscan.io/myapikey).
+:::
 
 ```shell
-subql codegen:generate \
--f <root path of your project> \ # Assumes current location if not provided
---abiPath <path of your abi file> \ # path is from project root - this is required
---startBlock <start block> # Required
---address <address> \ # Contract address
---events '*' \  # accepted formats: 'transfers, approval'
---functions '*' # accepted formats: 'transferFrom, approve'
+ETHERSCAN_API_KEY=<your-api-key> subql import-abi \
+-f ./example-project \
+--address 0x2e645469f354bb4f5c8a05b3b30a929361cf77ec \
+--events '*' \
+--functions '*'
 ```
 
-This will attempt to read the provided ABI file, and generate a list of events & functions in accordance. If `--events` or `--functions` are not provided, all available events\functions will be prompted, if `'*'` is provided, all events/functions will be selected. For example:
+#### From an ABI File
+
+If you have the ABI file saved locally, you can specify the path to the ABI file using the `--abiPath` option. This allows you to import the ABI from a local file and generate the necessary changes.
 
 ```shell
-subql codegen:generate \
+subql import-abi \
 -f './example-project' \
---abiPath './abis/erc721.json' \ (required)
---startBlock 1 \ (required)
+--abiPath './abis/erc721.json'
+--startBlock 1 \ # The block number when the contract was deployed
 --address '0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D' \
 --events '*' \
 --functions '*'
 ```
 
-### What is Scaffolded?
+### What is changed?
 
-Once completed, you will have a scaffolded project structure from your chosen ABI `functions`/`events`.
+Once completed, you will have an updated project structure from your chosen ABI `functions`/`events`.
 
-In the previous example for the [Ethereum Gravatar indexer](../quickstart/quickstart_chains/ethereum-gravatar.md), I have selected the events `NewGravatar` and `UpdatedGravatar` to scaffold.
+In the previous example for the [Ethereum Gravatar indexer](../quickstart/quickstart_chains/ethereum-gravatar.md), I have selected the events `NewGravatar` and `UpdatedGravatar` to import.
 
 It initialises the correct manifest with Log Handlers included, as well a new typescript file `<abiName>Handler.ts` containing mapping functions and imports with the appropriate typing..
 

--- a/docs/indexer/build/manifest/algorand.md
+++ b/docs/indexer/build/manifest/algorand.md
@@ -166,7 +166,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. In Algorand it is always the genesis hash of the network (hash of the first block).
 

--- a/docs/indexer/build/manifest/arbitrum.md
+++ b/docs/indexer/build/manifest/arbitrum.md
@@ -195,7 +195,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in Arbitrum is `42161` for Arbitrum One and `42170` for Arbitrum Nova. See https://chainlist.org/chain/42161
 

--- a/docs/indexer/build/manifest/avalanche.md
+++ b/docs/indexer/build/manifest/avalanche.md
@@ -206,7 +206,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain, for Avalanche this is `43114`. See https://chainlist.org/chain/43114
 

--- a/docs/indexer/build/manifest/bsc.md
+++ b/docs/indexer/build/manifest/bsc.md
@@ -195,7 +195,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in BNB Smart Chain (BSC) is `56` for mainnet. See https://chainlist.org/chain/56
 

--- a/docs/indexer/build/manifest/concordium.md
+++ b/docs/indexer/build/manifest/concordium.md
@@ -126,7 +126,7 @@ export default project;
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. In Concordium it is always the genesis hash of the network (hash of the first block). This is `4221332d34e1694168c2a0c0b3fd0f273809612cb13d000d5c2e00e85f50f796` for testnet.
 

--- a/docs/indexer/build/manifest/cosmos.md
+++ b/docs/indexer/build/manifest/cosmos.md
@@ -178,7 +178,7 @@ We expect that SubQuery will work with all Ethermint and CosmWasm Cosmos chains 
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the Cosmos Zone. Examples in Cosmos might be `juno-1`. You can often search for this in https://github.com/cosmos/chain-registry.
 

--- a/docs/indexer/build/manifest/ethereum.md
+++ b/docs/indexer/build/manifest/ethereum.md
@@ -193,7 +193,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in Ethereum is `1` for mainnet, `3` for Ropsten, and `4` for Rinkeby. See https://chainlist.org/chain/1
 

--- a/docs/indexer/build/manifest/flare.md
+++ b/docs/indexer/build/manifest/flare.md
@@ -192,7 +192,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in Flare is `14` for Flare mainnet and `19` for Songbird. See https://chainlist.org/chain/14
 

--- a/docs/indexer/build/manifest/gnosis.md
+++ b/docs/indexer/build/manifest/gnosis.md
@@ -204,7 +204,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. In Gnosis it is `100`. See https://chainlist.org/chain/100
 

--- a/docs/indexer/build/manifest/near.md
+++ b/docs/indexer/build/manifest/near.md
@@ -208,7 +208,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. In NEAR, it's either `mainnet` or `testnet`.
 

--- a/docs/indexer/build/manifest/optimism.md
+++ b/docs/indexer/build/manifest/optimism.md
@@ -203,7 +203,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. In Optimism it is `10`. See https://chainlist.org/chain/10.
 

--- a/docs/indexer/build/manifest/polkadot.md
+++ b/docs/indexer/build/manifest/polkadot.md
@@ -159,7 +159,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` or `genesisHash` is the network identifier of the blockchain. In Substrate it is always the genesis hash of the network (hash of the first block). You can retrieve this easily by going to [PolkadotJS](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fkusama.api.onfinality.io%2Fpublic-ws#/explorer/query/0) and looking for the hash on **block 0** (see the image below).
 

--- a/docs/indexer/build/manifest/polygon.md
+++ b/docs/indexer/build/manifest/polygon.md
@@ -196,7 +196,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in Polygon is `137` for Polygon mainnet and `8001` for Polygon Mumbai. See https://chainlist.org/chain/137
 

--- a/docs/indexer/build/manifest/solana.md
+++ b/docs/indexer/build/manifest/solana.md
@@ -160,7 +160,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain.
 

--- a/docs/indexer/build/manifest/starknet.md
+++ b/docs/indexer/build/manifest/starknet.md
@@ -177,7 +177,7 @@ repository: https://github.com/subquery/starknet-subql-starter
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain. Examples in Starknet is `0x534e5f4d41494e` for Mainnet, `0x534e5f5345504f4c4941` for Sepolia. You can find constants for the official networks in the [Starknet.js constants.ts file](https://github.com/starknet-io/starknet.js/blob/main/src/constants.ts#L42).
 

--- a/docs/indexer/build/manifest/stellar.md
+++ b/docs/indexer/build/manifest/stellar.md
@@ -192,7 +192,7 @@ dataSources:
 
 ### Network Spec
 
-If you start your project by using the `subql init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
+If you start your project by using the `npx @subql/cli init` command, you'll generally receive a starter project with the correct network settings. If you are changing the target chain of an existing project, you'll need to edit the [Network Spec](#network-spec) section of this manifest.
 
 The `chainId` is the network identifier of the blockchain, [Stellar and Soroban uses the network passphrase](https://developers.stellar.org/docs/encyclopedia/network-passphrases). Examples in Stellar are `Public Global Stellar Network ; September 2015` for mainnet and `Test SDF Future Network ; October 2022` for Future Network.
 

--- a/docs/indexer/build/substrate-evm.md
+++ b/docs/indexer/build/substrate-evm.md
@@ -38,7 +38,7 @@ Theoretically all the following networks (and more) should also be supported sin
 
 1. Add the custom datasource as a dependency:
 
-- Create a new project from an EVM template through `subql init` OR
+- Create a new project from an EVM template through `npx @subql/cli init` OR
 - For existing projects, `yarn add -D @subql/frontier-evm-processor` or `npm i @subql/acala-evm-processor --save-dev`.
 
 2. Add exports to your `package.json` like below in order for IPFS deployments to work

--- a/docs/indexer/build/substrate-wasm.md
+++ b/docs/indexer/build/substrate-wasm.md
@@ -10,7 +10,7 @@ There is a [friendly quick start guide that introduces SubQuery's Substrate WASM
 
 ## Getting started
 
-1. Add the custom datasource as a dependency. Create a new project from an WASM starter template though `subql init` OR for existing projects, `yarn add -D @subql/substrate-wasm-processor`.
+1. Add the custom datasource as a dependency. Create a new project from an WASM starter template though `npx @subql/cli init` OR for existing projects, `yarn add -D @subql/substrate-wasm-processor`.
 2. Import processor file to your `project.ts` like below
 
 ```ts

--- a/docs/indexer/build/testing.md
+++ b/docs/indexer/build/testing.md
@@ -196,7 +196,7 @@ subquery-node:
 To run tests with Docker, set the Docker SUB_COMMAND environment variable to "test" in the docker-compose.yml file. Then, use the following command to start the Docker container (tests will be run on startup automatically):
 
 ```
-SUB_COMMAND=test docker-compose pull && docker-compose up
+SUB_COMMAND=test docker compose pull && docker compose up
 ```
 
 ### Setting up GitHub Actions

--- a/docs/indexer/quickstart/quickstart.md
+++ b/docs/indexer/quickstart/quickstart.md
@@ -1,6 +1,6 @@
 # 1. SubQuery Hello World
 
-This quick start demonstrates how to get the Ethereum starter project, which indexes all transfers and approval events for the [wrapped Ether token](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) on Ethereum Mainnet up and running. This should take about 5 minutes. 
+This quick start demonstrates how to get the Ethereum starter project, which indexes all transfers and approval events for the [wrapped Ether token](https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2) on Ethereum Mainnet up and running. This should take about 5 minutes.
 
 ## Prerequisites
 
@@ -9,7 +9,7 @@ Before you begin creating your first blockchain project with SubQuery, make sure
 - [NodeJS](https://nodejs.org/en/): A modern (e.g. the LTS version) installation of NodeJS.
 - [Docker](https://docker.com/): This tutorial will use Docker to run a local version of SubQuery's node.
 
-To check if you have Node or Docker already, run: 
+To check if you have Node or Docker already, run:
 ```shell
 node -v
 v22.15.0
@@ -29,13 +29,13 @@ npx @subql/cli init
 You'll be asked certain questions as you proceed ahead:
 
 - **Project name**: A project name for your SubQuery project.
-- **Network family**: The layer-1 blockchain network family that this SubQuery project will index. Use the arrow keys to select from the available options (scroll down as there are multiple pages).
 - **Network**: The specific network that this SubQuery project will index. Use the arrow keys to select from the available options (scroll down as there are multiple pages).
 - **Template project**: Select a SubQuery template project that will serve as a starting point for your project. For some networks, multiple examples are provided.
 - **RPC endpoint**: Provide an HTTP or websocket URL to a running RPC endpoint which will be used by this project. You can use public endpoints for different networks, your own private dedicated node, or just use the default endpoint. This RPC node must have the entire state of the data that you wish to index, so an archive node is recommended.
 - **Authors**: Enter the owner of this SubQuery project here. eg. your name or organisation.
 - **Description**: Provide a short paragraph about your project that describes what the project does.
-- **Generate scaffolding from an existing contract ABI?**: Enter a local path to an ABI.json file afterwhich the project will automatically create the events and methods. Learn more [here](../build/introduction.md#directory-structure).
+- **Do you want to generate datasources and handlers from an existing contract ABI?**: Enter a local path to an ABI.json file afterwhich the project will automatically create the events and methods. Learn more [here](../build/introduction#evm-abi-importing).
+
 
 Let’s look at an example:
 
@@ -49,17 +49,17 @@ Project name [subql-starter]: evm-hello-world
 ? Author SubQuery Team
 ? Description This project can be use as a starting po...
 evm-hello-world is ready
-? Do you want to generate scaffolding from an existing contract abi? no
+? Do you want to generate datasources and handlers from an existing contract ABI? no
 
 ```
 
 :::info EVM Based Projects
 
-SubQuery projects can be generated from ABIs to save time when creating EVM based projects. Please see [EVM Project Scaffolding](#evm-project-scaffolding)
+SubQuery projects can import ABIs to generate datasources and their handlers. Please see [EVM ABI Importing](../build/introduction#evm-abi-importing)
 
 :::
 
-After you complete the initialisation process, you will see a folder with your project name created inside the directory. Please note that the contents of this directory should be near identical to what's listed in the [Directory Structure](../build/introduction.md#directory-structure).
+After you complete the initialisation process, you will see a folder with your project name created inside the directory. Please note that the contents of this directory should be near identical to what's listed in the [Directory Structure](../build/introduction#directory-structure).
 
 ## 2. Install dependencies
 
@@ -99,7 +99,7 @@ yarn dev
 
 :::
 
-This command actually runs 3 subcommands under the hood for convenience. 
+This command actually runs 3 subcommands under the hood for convenience.
 
 * `npm run codegen` - This generates types from the GraphQL schema definition and contract ABIs and saves them in the /src/types directory. This must be done after each change to the schema.graphql file or the contract ABIs.
 * `npm run build` - This builds and packages the SubQuery project into the /dist directory.
@@ -144,7 +144,7 @@ Because a free public RPC endpoint is used in the default configuration, sometim
 ```
  Error: All endpoints failed to initialize. Please add healthier endpoints
  ```
- 
+
  To resolve this, sign up for a free account at [OnFinality](https://onfinality.io/) or any other RPC provider and to obtain a more stable RPC endpoint and update the .env file.
 
 
@@ -239,5 +239,3 @@ Expected results:
 :::
 
 Congratulations! You have successfully created your first SubQuery project indexing transfers and approvals for the wrapped ether token on Ethereum mainnet!
-
-

--- a/docs/indexer/quickstart/quickstart_chains/cosmos-other.md
+++ b/docs/indexer/quickstart/quickstart_chains/cosmos-other.md
@@ -1,6 +1,6 @@
 # Other Supported Cosmos Zones
 
-Although we only list quick start guides for select Cosmos zones - SubQuery has been tested to support most zones that that use CosmWasm, Tendermint, or Ethermint. You can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `subql init` command:
+Although we only list quick start guides for select Cosmos zones - SubQuery has been tested to support most zones that that use CosmWasm, Tendermint, or Ethermint. You can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `npx @subql/cli init` command:
 
 CosmWasm Projects:
 

--- a/docs/indexer/quickstart/quickstart_chains/evm.md
+++ b/docs/indexer/quickstart/quickstart_chains/evm.md
@@ -1,6 +1,6 @@
 # Other EVM Networks
 
-Although we only list quick start guides for select EVM based networks - SubQuery has been tested to support all standard EVM implementations. You can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `subql init` command:
+Although we only list quick start guides for select EVM based networks - SubQuery has been tested to support all standard EVM implementations. You can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `npx @subql/cli init` command:
 
 View the full list of tested EVM projects in [the ethereum-subql-starter repository](https://github.com/subquery/ethereum-subql-starter).
 

--- a/docs/indexer/quickstart/quickstart_chains/polkadot-other.md
+++ b/docs/indexer/quickstart/quickstart_chains/polkadot-other.md
@@ -1,6 +1,6 @@
 # Other Supported Polkadot/Substrate Chains
 
-Although we only list quick start guides for select Polkadot networks - SubQuery has been tested to support most Polkadot parachains and standalone Substrate chains and you can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `subql init` command.
+Although we only list quick start guides for select Polkadot networks - SubQuery has been tested to support most Polkadot parachains and standalone Substrate chains and you can quickly initialise a new project in any [supported network](https://subquery.network/networks) using the `npx @subql/cli init` command.
 
 View the full list of tested projects in [the subql-starter repository](https://github.com/subquery/subql-starter).
 

--- a/docs/indexer/run_publish/query/subgraph.md
+++ b/docs/indexer/run_publish/query/subgraph.md
@@ -35,7 +35,7 @@ Modify `docker-compose.yml` to update the graphql-engine image to `subquerynetwo
 Under the project directory run the following command:
 
 ```shell
-docker-compose pull && docker-compose up
+docker compose pull && docker compose up
 ```
 
 ::: tip Note It may take some time to download the required packages ([`@subql/node`](https://www.npmjs.com/package/@subql/node), [`@subql/query-subgraph`](https://www.npmjs.com/package/@subql/query-subgraph), and Postgres) for the first time but soon you'll see a running SubQuery node.

--- a/docs/indexer/run_publish/references.md
+++ b/docs/indexer/run_publish/references.md
@@ -4,28 +4,7 @@ All booleans are by default `false` unless explicitly mentioned.
 
 ## subql (cli)
 
-### --help
-
-This shows all the current command options for your current version of `subql-cli`.
-
-### build
-
-This command uses webpack to generate a bundle of a subquery project.
-
-| Options        | Description                                                 |
-| -------------- | ----------------------------------------------------------- |
-| -l, --location | local folder of subquery project (if not in folder already) |
-| -o, --output   | specify output folder of build e.g. build-folder            |
-| --mode         | `production` or `development` (default: `production`)       |
-
-- With `subql build` you can specify additional entry points in exports field although it will always build
-  `index.ts` automatically.
-
-- You need to have @subql/cli v0.19.0 or above to use exports field.
-
-- Any `exports` field must map to string type (e.g. `"entry": "./src/file.ts"`), else it will be ignored from build.
-
-For more info, visit [basic workflows](../build/introduction.md#build).
+You can view the latest CLI reference [here](https://github.com/subquery/subql/blob/main/packages/cli/README.md)
 
 ## subql-node
 

--- a/docs/indexer/run_publish/run.md
+++ b/docs/indexer/run_publish/run.md
@@ -19,7 +19,7 @@ An alternative solution is to run a **Docker Container**, defined by the `docker
 Under the project directory run the following command:
 
 ```shell
-docker-compose pull && docker-compose up
+docker compose pull && docker compose up
 ```
 
 ::: tip Note

--- a/docs/subquery_network/node_operators/setup/becoming-a-node-operator.md
+++ b/docs/subquery_network/node_operators/setup/becoming-a-node-operator.md
@@ -75,7 +75,7 @@ This will overwrite the existing docker-compose.yml file. Always use the latest 
 
 ::: warning Important
 
-Please go through the docker-compose file carefully, and change the following parameters to your own values:
+Please go through the docker compose file carefully, and change the following parameters to your own values:
 
 - Your `POSTGRES_PASSWORD` under your postgres container, as well as `--postgres-password` under coordinator container.
 - Your `--secret-key` under both coordinator and proxy containers.
@@ -175,7 +175,7 @@ mkdir network-indexer-services-temp && curl -L https://api.github.com/repos/subq
 
 This will generate a folder named `metrics` containing all the necessary setup files for your Dashboard.
 
-Before using the docker-compose file in the `metrics` directory, you should port over your previous changes from your backup that you created earlier, and make several additional modifications:
+Before using the docker compose file in the `metrics` directory, you should port over your previous changes from your backup that you created earlier, and make several additional modifications:
 
 1. Open the `docker-compose-metrics.yml` file and update the `GF_SECURITY_ADMIN_PASSWORD` variable. This is the password you'll use to log in to the Grafana dashboard.
 2. Navigate to `metrics/datasources/datasource.yml` and update the Authorization token. It should match the `--metrics-token` specified in the proxy container section of your `docker-compose.yml` file.
@@ -194,7 +194,7 @@ You can get this for `indexer-proxy` and `indexer-coordinator` by running:
 After doing this configuration you can start up the compose file:
 
 ```bash
-docker-compose -f ./metrics/docker-compose-metrics.yml up -d
+docker compose -f ./metrics/docker-compose-metrics.yml up -d
 ```
 
 Head to `http://<indexer-endpoint>:3000`, your username will be `admin` and password will be whatever you set for `GF_SECURITY_ADMIN_PASSWORD`

--- a/docs/subquery_network/node_operators/setup/faq.md
+++ b/docs/subquery_network/node_operators/setup/faq.md
@@ -52,7 +52,7 @@ However, we don't support applying the changed password to the existing data at 
 docker exec -i db_container_id psql -U postgres -c "ALTER USER postgres WITH PASSWORD 'your_password'"
 
 // 2. restart docker compose
-docker-compose up -d
+docker compose up -d
 
 // 3. For the running projects, there is a tricky way to force the “restart the
 // project” with a new DB password. (force restart to be supported as an option flag in the future).
@@ -137,7 +137,7 @@ There are a number of options to solve this:
      - Requires additional configuration to fix up the way Docker creates networks which allow the containers to talk to each other.
 2. Use `expose` instead of `ports` in the `docker-compose.yml`.
    - Pros:
-     - Nice and neat as the change is only in the docker-compose file which is where we are defining the rest of the behaviour in our stack.
+     - Nice and neat as the change is only in the docker compose file which is where we are defining the rest of the behaviour in our stack.
    - Cons:
      - The `query_` containers that are created to index a project need to talk to other containers in the stack. They do this by running on a specific port. And it gets allocated when they are created starting at 3000 and are incremented with each project indexed.
      - That makes `expose` a little inconvenient/complex- either suffer the disruption of adding/removing the internal port as projects are added/removed, or just expose a bunch (3000 - 3100 for example) up front and hope you don't forget when your 101st project won't index.

--- a/docs/subquery_network/node_operators/setup/install-linux.md
+++ b/docs/subquery_network/node_operators/setup/install-linux.md
@@ -38,7 +38,7 @@ sudo systemctl enable docker
 sudo systemctl start docker
 ```
 
-- Note that you need to install the docker-compose command tool in EC2, in order to use the docker-compose features:
+- Note that you need to install the docker compose command tool in EC2, in order to use the docker compose features:
 
 ```bash
 # get the latest version for docker-compose
@@ -48,7 +48,7 @@ sudo curl -L https://github.com/docker/compose/releases/latest/download/docker-c
 sudo chmod +x /usr/bin/docker-compose
 
 # verify the installation
-sudo docker-compose version
+sudo docker compose version
 ```
 
 ### Step 3 - Download the Docker Compose File for Node Operator Services
@@ -69,7 +69,7 @@ Please change the `POSTGRES_PASSWORD` in postgres and `postgres-password` in coo
 Run the service using the following command:
 
 ```bash
-sudo docker-compose up -d
+sudo docker compose up -d
 ```
 
 It will start the following services:
@@ -106,7 +106,7 @@ SyslogIdentifier=subquery
 SyslogFacility=local7
 KillSignal=SIGHUP
 WorkingDirectory=/home/ec2-user/subquery-indexer
-ExecStart=/usr/bin/docker-compose up -d
+ExecStart=/usr/bin/docker compose up -d
 
 [Install]
 WantedBy=multi-user.target

--- a/docs/subquery_network/node_operators/setup/install-local-docker.md
+++ b/docs/subquery_network/node_operators/setup/install-local-docker.md
@@ -44,7 +44,7 @@ If you are running in Kubernetes (k8s), make sure to set the `host-env` paramete
 Run the following command to start the Node Operator service:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Please check that the Docker is already running. The images will be pulled from Docker and then it will start the following services:

--- a/docs/subquery_network/node_operators/setup/security-guide.md
+++ b/docs/subquery_network/node_operators/setup/security-guide.md
@@ -138,7 +138,7 @@ proxy:
 then restart the `indexer-proxy` container
 
 ```shell
-docker-compose up -d
+docker compose up -d
 ```
 
 3.4. Config Nginx: Edit your Nginx configuration (usually found at `/etc/nginx/conf.d/proxy.mysqindexer.com.conf`, create one if it does not exist) to add the following:

--- a/docs/subquery_network/node_operators/setup/troubleshooting.md
+++ b/docs/subquery_network/node_operators/setup/troubleshooting.md
@@ -3,12 +3,12 @@
 ## Got permission denied while trying to connect to the Docker daemon socket
 
 ```bash
-[ec2-user@example subquery-indexer]$ docker-compose up
+[ec2-user@example subquery-indexer]$ docker compose up
 Got permission denied while trying to connect to the Docker daemon socket
 at unix:///var/run/docker.sock: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/containers/json?all=1&filters=%7B%22label%22%3A%7B%22com.docker.compose.project%3Dsubquery-indexer%22%3Atrue%7D%7D&limit=0": dial unix /var/run/docker.sock: connect: permission denied
 ```
 
-You get this error because the user you have logged in through does not have permission to run the docker-compose up command.
+You get this error because the user you have logged in through does not have permission to run the docker compose up command.
 
 **Solution:**
 Run the following command, then log out, and log in again.
@@ -20,7 +20,7 @@ sudo usermod -aG docker ${USER}
 The alternative solution is to run as sudo user:
 
 ```bash
-sudo docker-compose up
+sudo docker compose up
 
 
 ```
@@ -120,7 +120,7 @@ Try to uninstall Docker Compose and re-install it from the official guide rather
 - `sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose`
 - `sudo chmod +x /usr/local/bin/docker-compose`
 
-If all has worked you should get `docker-compose version 1.29.2, build 5becea4c` from `docker-compose --version`, and you can go ahead and pull/up.
+If all has worked you should get `docker compose version 1.29.2, build 5becea4c` from `docker compose --version`, and you can go ahead and pull/up.
 
 The official installation guide can be found [here](https://docs.docker.com/compose/install/#install-compose-on-linux-systems).
 


### PR DESCRIPTION
Update docs relating to what was previously called scaffolding, this was not a very clear terminology. Now we're calling it importing ABIs.

There are also loads of other small changes:
* Rename `docker-compose` to `docker compose`
* Change `subql init` and global install to `npx @subql/cli init`
* Remove `cli` reference docs and instead link to generated docs on github
* Update install instructions and suggest not installing globally
* Fix some broken links